### PR TITLE
feat: 起動時の入口画面決定ロジック（TDD）

### DIFF
--- a/novelit/EntryScreenDecider.swift
+++ b/novelit/EntryScreenDecider.swift
@@ -1,0 +1,34 @@
+//
+//  EntryScreenDecider.swift
+//  novelit
+//
+//  Created by 村崎聖仁 on 2026/01/25.
+//
+
+enum EntryScreen: Equatable {
+    case signIn
+    case verifyingAppleSignIn
+    case home
+}
+
+enum AppleSignInVerification: Equatable {
+    case unknown
+    case authorized
+    case unauthorized
+}
+
+func decideEntryScreen(
+    appleUserId: String?,
+    verification: AppleSignInVerification
+) -> EntryScreen {
+    guard appleUserId != nil else { return .signIn }
+
+    switch verification {
+    case .unknown:
+        return .verifyingAppleSignIn
+    case .authorized:
+        return .home
+    case .unauthorized:
+        return .signIn
+    }
+}

--- a/novelitTests/EntryScreenDeciderTests.swift
+++ b/novelitTests/EntryScreenDeciderTests.swift
@@ -1,0 +1,33 @@
+//
+//  Untitled.swift
+//  novelit
+//
+//  Created by 村崎聖仁 on 2026/01/24.
+//
+
+import Testing
+@testable import novelit
+
+struct EntryScreenDeciderTests {
+    @Test("未ログイン（userIdなし）は常に.signIn")
+    func signedOutAlwaysGoesToSignIn() {
+        #expect(decideEntryScreen(appleUserId: nil, verification: .unknown) == .signIn)
+        #expect(decideEntryScreen(appleUserId: nil, verification: .authorized) == .signIn)
+        #expect(decideEntryScreen(appleUserId: nil, verification: .unauthorized) == .signIn)
+    }
+    
+    @Test("ログイン済み（userIdあり） + 未確認は.verifyingAppleSignIn")
+    func signedInUnknownGoesToVerifyingAppleSignIn() {
+        #expect(decideEntryScreen(appleUserId: "u1", verification: .unknown) == .verifyingAppleSignIn)
+    }
+    
+    @Test("ログイン済み（userIdあり） + authorizedは.home")
+    func signedInAuthorizedGoesToHome() {
+        #expect(decideEntryScreen(appleUserId: "u1", verification: .authorized) == .home)
+    }
+    
+    @Test("ログイン済み（userIdあり） + unauthorizedは安全側で.signIn")
+    func signedInUnauthorizedGoesToSignIn() {
+        #expect(decideEntryScreen(appleUserId: "u1", verification: .unauthorized) == .signIn)
+    }
+}


### PR DESCRIPTION
入口画面の決定ロジックをTDDで追加しました。

- `EntryScreen`（`.signIn` / `.verifyingAppleSignIn` / `.home`）
- `AppleSignInVerification`（`.unknown` / `.authorized` / `.unauthorized`）
- `decideEntryScreen(appleUserId:verification:)` の実装
- 仕様を固定するユニットテスト（Swift Testing）

テスト:
```sh
xcodebuild -project novelit.xcodeproj -scheme novelit -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test -only-testing:novelitTests
```
