### PR TITLE
[MVP-2] Sign in with Apple実装 + 同一ID再サインインP1修正

### DIFF
--- a/novelitTests/novelitTests.swift
+++ b/novelitTests/novelitTests.swift
@@ -125,6 +125,33 @@ struct AppleUserSessionReducerTests {
         #expect(reduced.storedAppleUserId == "")
         #expect(reduced.signInErrorMessage == nil)
     }
+
+    @Test("同一appleUserIdで再サインインしたとき再検証用revisionを進める")
+    func signInSuccessWithSameUserIdIncrementsRevision() {
+        let state = AppleUserSessionState(
+            storedAppleUserId: "apple-user-1",
+            signInErrorMessage: nil,
+            verificationRevision: 3
+        )
+
+        let reduced = reduceAppleUserSession(
+            state: state,
+            action: .signInSucceeded(appleUserId: "apple-user-1")
+        )
+
+        #expect(reduced.storedAppleUserId == "apple-user-1")
+        #expect(reduced.verificationRevision == 4)
+    }
+}
+
+struct RootViewTaskIDTests {
+    @Test("同一appleUserIdでもrevisionが変わればtask idが変わる")
+    func taskIDChangesWhenRevisionChanges() {
+        let first = makeRootTaskID(storedAppleUserId: "apple-user-1", verificationRevision: 1)
+        let second = makeRootTaskID(storedAppleUserId: "apple-user-1", verificationRevision: 2)
+
+        #expect(first != second)
+    }
 }
 
 struct novelitTests {


### PR DESCRIPTION
## 概要
MVP-2（Sign in with Apple 実ログイン処理）を実装し、同一Apple IDで再サインインしたときに再検証が走らないP1不具合を修正しました。

Closes #17

## 変更内容
- `SignInWithAppleButton` を実装し、成功時に `appleUserId` を保存
- サインイン失敗時のエラーメッセージ表示を追加
- `AppleUserSessionAction/State/reducer` を導入して状態遷移を統一
- ホーム画面にログアウト導線を追加
- `verificationRevision` を導入し、同一ID再サインイン時でも再検証が走るよう修正
- `RootTaskID` を導入し、`task(id:)` の監視キーを `userId + revision` に変更

## テスト
- `AppleUserSessionReducerTests/signInSuccessStoresAppleUserId`
- `AppleUserSessionReducerTests/signInFailureDoesNotSaveAppleUserId`
- `AppleUserSessionReducerTests/signOutClearsAppleUserId`
- `AppleUserSessionReducerTests/signInSuccessWithSameUserIdIncrementsRevision`
- `RootViewTaskIDTests/taskIDChangesWhenRevisionChanges`

実行コマンド:
- `xcodebuild -project novelit.xcodeproj -scheme novelit -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:novelitTests -quiet`

補足:
- 既存の `RootViewModelTests/signedInBecomesSignInOnUnauthorized()` は環境依存でフレークすることがあり、今回のPRでは既存不安定要素として据え置きです。
