### PR TITLE
[MVP-6] 一覧→エディタ→履歴のUIフロー実装

### DIFF
--- a/novelit/HomeFlowReducer.swift
+++ b/novelit/HomeFlowReducer.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+enum HomeFlowRoute: Equatable {
+    case list
+    case editor(fileName: String)
+    case history(fileName: String)
+}
+
+enum EditorPanel: String, Equatable, CaseIterable, Identifiable {
+    case explorer
+    case changes
+    case graph
+
+    var id: String {
+        rawValue
+    }
+
+    var displayTitle: String {
+        switch self {
+        case .explorer:
+            return "Explorer"
+        case .changes:
+            return "Changes"
+        case .graph:
+            return "Graph"
+        }
+    }
+}
+
+struct HomeFlowState: Equatable {
+    var route: HomeFlowRoute = .list
+    var activePanel: EditorPanel? = nil
+}
+
+enum HomeFlowAction: Equatable {
+    case openEditor(fileName: String)
+    case backToList
+    case openHistory
+    case backToEditor
+    case togglePanel(EditorPanel)
+    case closePanel
+}
+
+func reduceHomeFlow(state: HomeFlowState, action: HomeFlowAction) -> HomeFlowState {
+    switch action {
+    case .openEditor(let fileName):
+        return HomeFlowState(route: .editor(fileName: fileName), activePanel: nil)
+
+    case .backToList:
+        return HomeFlowState(route: .list, activePanel: nil)
+
+    case .openHistory:
+        guard case let .editor(fileName) = state.route else {
+            return state
+        }
+        return HomeFlowState(route: .history(fileName: fileName), activePanel: nil)
+
+    case .backToEditor:
+        guard case let .history(fileName) = state.route else {
+            return state
+        }
+        return HomeFlowState(route: .editor(fileName: fileName), activePanel: nil)
+
+    case .togglePanel(let panel):
+        guard case .editor = state.route else {
+            return state
+        }
+
+        let nextPanel: EditorPanel? = state.activePanel == panel ? nil : panel
+        return HomeFlowState(route: state.route, activePanel: nextPanel)
+
+    case .closePanel:
+        guard state.activePanel != nil else {
+            return state
+        }
+        return HomeFlowState(route: state.route, activePanel: nil)
+    }
+}

--- a/novelitTests/HomeFlowReducerTests.swift
+++ b/novelitTests/HomeFlowReducerTests.swift
@@ -1,0 +1,70 @@
+import Testing
+@testable import novelit
+
+struct HomeFlowReducerTests {
+    @Test("初期状態は一覧表示でパネル未選択")
+    func initialStateIsListWithNoPanel() {
+        let state = HomeFlowState()
+
+        #expect(state.route == .list)
+        #expect(state.activePanel == nil)
+    }
+
+    @Test("一覧からファイルを開くとエディタへ遷移し、パネルは閉じる")
+    func openEditorMovesToEditorAndClearsPanel() {
+        let initial = HomeFlowState(route: .list, activePanel: .graph)
+
+        let reduced = reduceHomeFlow(state: initial, action: .openEditor(fileName: "sample.md"))
+
+        #expect(reduced.route == .editor(fileName: "sample.md"))
+        #expect(reduced.activePanel == nil)
+    }
+
+    @Test("エディタで同じパネルを再タップすると閉じる")
+    func tappingSamePanelTwiceClosesPanel() {
+        let initial = HomeFlowState(route: .editor(fileName: "sample.md"), activePanel: .explorer)
+
+        let reduced = reduceHomeFlow(state: initial, action: .togglePanel(.explorer))
+
+        #expect(reduced.activePanel == nil)
+    }
+
+    @Test("エディタで別パネルをタップすると切り替わる")
+    func tappingDifferentPanelSwitchesPanel() {
+        let initial = HomeFlowState(route: .editor(fileName: "sample.md"), activePanel: .explorer)
+
+        let reduced = reduceHomeFlow(state: initial, action: .togglePanel(.changes))
+
+        #expect(reduced.activePanel == .changes)
+    }
+
+    @Test("エディタから履歴へ遷移すると編集中ファイル名を引き継ぎ、パネルは閉じる")
+    func openHistoryMovesToHistoryKeepingFileName() {
+        let initial = HomeFlowState(route: .editor(fileName: "sample.md"), activePanel: .graph)
+
+        let reduced = reduceHomeFlow(state: initial, action: .openHistory)
+
+        #expect(reduced.route == .history(fileName: "sample.md"))
+        #expect(reduced.activePanel == nil)
+    }
+
+    @Test("履歴から戻るとエディタへ戻る")
+    func backToEditorFromHistory() {
+        let initial = HomeFlowState(route: .history(fileName: "sample.md"), activePanel: nil)
+
+        let reduced = reduceHomeFlow(state: initial, action: .backToEditor)
+
+        #expect(reduced.route == .editor(fileName: "sample.md"))
+    }
+
+    @Test("一覧画面でエディタ専用アクションを受けても状態は変わらない")
+    func editorOnlyActionsAreIgnoredInList() {
+        let initial = HomeFlowState(route: .list, activePanel: nil)
+
+        let afterToggle = reduceHomeFlow(state: initial, action: .togglePanel(.explorer))
+        let afterHistory = reduceHomeFlow(state: initial, action: .openHistory)
+
+        #expect(afterToggle == initial)
+        #expect(afterHistory == initial)
+    }
+}


### PR DESCRIPTION
## 概要
MVP-6 の最小UIフロー（一覧 → エディタ → 履歴）を追加しました。  
加えて、エディタ下部のパネル導線（Explorer / Changes / Graph）をプレースホルダで接続しています。

## 変更内容
- `HomeFlowReducer` を追加
  - 画面ルート（一覧/エディタ/履歴）
  - パネル開閉状態（Explorer/Changes/Graph）
  - Action ベースの状態遷移
- `ContentView` を `HomeFlowState` 駆動に変更
  - 一覧から作品を開く
  - エディタから履歴を開く
  - 履歴からエディタへ戻る
- パネルシートのプレースホルダを追加
  - 同じタブを再タップで閉じる
  - 左上に `閉じる` ボタンを配置
- `HomeFlowReducerTests` を追加して遷移仕様を固定

## 補足
このPRは `MVP-3` の上に積んだ差分です（stacked PR）。  
`MVP-3` マージ後に base を `main` へ変更する想定です。

## Issue
Closes #11
