### PR TITLE
feat(mvp-9): 新規作品作成フローとテンプレ選択を実装

### DIFF
--- a/novelit/WritingModels.swift
+++ b/novelit/WritingModels.swift
@@ -320,11 +320,17 @@ struct WorkFactory {
 
         switch template {
         case .minimal:
+            addMinimalTemplateNodes(to: work, now: now)
             return work
         case .standard:
             addStandardTemplateNodes(to: work, now: now)
             return work
         }
+    }
+
+    private static func addMinimalTemplateNodes(to work: Work, now: Date) {
+        let contentNode = makeFileNode(name: "content", kind: .content, now: now)
+        work.nodes.append(contentNode)
     }
 
     private static func addStandardTemplateNodes(to work: Work, now: Date) {
@@ -349,4 +355,27 @@ struct WorkFactory {
         node.document = document
         return node
     }
+}
+
+func makeAutoWorkTitle(existingTitles: [String], prefix: String = "作品") -> String {
+    let maxNumber = existingTitles
+        .compactMap { title -> Int? in
+            guard title.hasPrefix(prefix) else {
+                return nil
+            }
+
+            let suffix = title.dropFirst(prefix.count)
+            guard
+                !suffix.isEmpty,
+                suffix.allSatisfy(\.isNumber),
+                let number = Int(suffix)
+            else {
+                return nil
+            }
+
+            return number
+        }
+        .max() ?? 0
+
+    return "\(prefix)\(maxNumber + 1)"
 }

--- a/novelitTests/DataModelTests.swift
+++ b/novelitTests/DataModelTests.swift
@@ -24,6 +24,32 @@ struct DataModelTests {
         #expect(snapshotsNode?.document == nil)
     }
 
+    @Test("ミニマルテンプレートはcontentのみを生成する")
+    func minimalTemplateCreatesContentOnly() {
+        let work = WorkFactory.create(title: "ミニマル作品", template: .minimal)
+
+        #expect(work.rootNodes.count == 1)
+        #expect(work.rootNodes.first?.name == "content")
+        #expect(work.document(kind: .content) != nil)
+        #expect(work.document(kind: .outline) == nil)
+    }
+
+    @Test("自動命名は既存作品タイトルから次の番号を採番する")
+    func autoWorkTitleGeneratesNextNumber() {
+        let title = makeAutoWorkTitle(
+            existingTitles: ["作品1", "メモ", "作品3", "作品X", "作品10"]
+        )
+
+        #expect(title == "作品11")
+    }
+
+    @Test("自動命名は対象タイトルがない場合に作品1を返す")
+    func autoWorkTitleStartsFromOne() {
+        let title = makeAutoWorkTitle(existingTitles: ["下書き", "プロット"])
+
+        #expect(title == "作品1")
+    }
+
     @Test("作品作成後に本文を更新できる")
     func updateBodyAfterCreatingWork() {
         let createdAt = Date(timeIntervalSince1970: 1_700_000_000)


### PR DESCRIPTION
## 概要
- 一覧右上に新規作成ボタンを追加（歯車の左）
- 新規作成時にテンプレート（標準/ミニマル）を選べるシートを追加
- 作品名を自動命名（`作品N`）して保存し、作成後はそのままエディタへ遷移
- ミニマルテンプレートを `content` のみ生成する仕様に調整

## 変更ファイル
- `novelit/ContentView.swift`
- `novelit/WritingModels.swift`
- `novelitTests/DataModelTests.swift`

## テスト
- 追加済み（未実行）
  - ミニマルテンプレートが `content` のみ生成すること
  - 自動命名ロジック（次番号採番/初期値）
